### PR TITLE
cast time to int to prevent auto coercion later

### DIFF
--- a/starship.mx
+++ b/starship.mx
@@ -44,7 +44,7 @@ event onPrompt starship=before {
 }
 
 event onPrompt starship=after {
-    ENV.STARSHIP_START_TIME = datetime(--in {now} --out {unix})
+    datetime --in {now} --out {unix} -> cast int -> set ENV.STARSHIP_START_TIME
 }
 
 config set shell hint-text-func {


### PR DESCRIPTION
the current onPrompt code results in a typing error, as murex attempts to coerce ENV.STARSHIP_START_TIME to float during math operations.

this PR explicitly casts said variable to an int, fixing the issue.